### PR TITLE
convert images to webp for performance

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,68 @@
+name: Build and Deploy Jekyll with WebP
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Cache WebP conversions
+        uses: actions/cache@v4
+        with:
+          path: _site/assets/images/**/*.webp
+          key: webp-cache-${{ hashFiles('assets/images/**/*.{jpg,jpeg,png,JPG,JPEG,PNG}') }}
+          restore-keys: |
+            webp-cache-
+
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick webp
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,10 +1,9 @@
-name: Build and Deploy Jekyll with WebP
+name: Build and Deploy Jekyll
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
   workflow_dispatch:
 
 permissions:
@@ -26,7 +25,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Cache WebP conversions
@@ -65,5 +64,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Cache WebP conversions

--- a/_includes/featuredbox.html
+++ b/_includes/featuredbox.html
@@ -15,10 +15,17 @@
                             {% endunless %}
                             {% assign img_url = img_url | replace: '//', '/' | replace: ':/', '://' %}
 
+                            {% assign webp_url = img_url | replace: '.jpg', '.webp' | replace: '.jpeg', '.webp' | replace: '.png', '.webp' | replace: '.JPG', '.webp' | replace: '.JPEG', '.webp' | replace: '.PNG', '.webp' %}
                             {% if site.lazyimages == "enabled" %}
-                            <img class="featured-box-img-cover lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" style="object-fit: cover;" decoding="async">
+                            <picture>
+                                <source type="image/webp" data-srcset="{{ webp_url }}">
+                                <img class="featured-box-img-cover lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" style="object-fit: cover;" decoding="async">
+                            </picture>
                             {% else %}
-                            <img class="featured-box-img-cover" src="{{ img_url }}" style="object-fit: cover;" loading="lazy" decoding="async">
+                            <picture>
+                                <source type="image/webp" srcset="{{ webp_url }}">
+                                <img class="featured-box-img-cover" src="{{ img_url }}" style="object-fit: cover;" loading="lazy" decoding="async">
+                            </picture>
                             {% endif %}
                             {% if post.tags %}
                                 <div class="post-tag">

--- a/_includes/picturebox.html
+++ b/_includes/picturebox.html
@@ -8,10 +8,17 @@
     {% assign img_url = img_url | replace: '//', '/' | replace: ':/', '://' %}
     
     <a href="{{ site.baseurl }}{{ post.url }}" style="display: block; width: 100%; {% if include.masonry != true %}height: 100%; position: absolute; top: 0; left: 0;{% else %}position: relative;{% endif %}">
+        {% assign webp_url = img_url | replace: '.jpg', '.webp' | replace: '.jpeg', '.webp' | replace: '.png', '.webp' | replace: '.JPG', '.webp' | replace: '.JPEG', '.webp' | replace: '.PNG', '.webp' %}
         {% if site.lazyimages == "enabled" and include.disable_lazy != true %}
-            <img class="img-fluid lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; {% if include.masonry != true %}height: 100%; object-fit: cover;{% else %}height: auto; display: block;{% endif %}" decoding="async">
+            <picture>
+                <source type="image/webp" data-srcset="{{ webp_url }}">
+                <img class="img-fluid lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; {% if include.masonry != true %}height: 100%; object-fit: cover;{% else %}height: auto; display: block;{% endif %}" decoding="async">
+            </picture>
         {% else %}
-            <img class="img-fluid" src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; {% if include.masonry != true %}height: 100%; object-fit: cover;{% else %}height: auto; display: block;{% endif %}" {% if include.disable_lazy != true %}loading="lazy"{% else %}fetchpriority="high"{% endif %} decoding="async">
+            <picture>
+                <source type="image/webp" srcset="{{ webp_url }}">
+                <img class="img-fluid" src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; {% if include.masonry != true %}height: 100%; object-fit: cover;{% else %}height: auto; display: block;{% endif %}" {% if include.disable_lazy != true %}loading="lazy"{% else %}fetchpriority="high"{% endif %} decoding="async">
+            </picture>
         {% endif %}
         
         <div class="picture-overlay" style="position: absolute; bottom: 0; left: 0; right: 0; background: linear-gradient(to top, rgba(0,0,0,0.9) 0%, rgba(0,0,0,0.4) 60%, transparent 100%); padding: 30px 15px 15px; text-align: left; transition: all 0.3s ease;">

--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -10,10 +10,17 @@
                     {% endunless %}
                     {% assign img_url = img_url | replace: '//', '/' | replace: ':/', '://' %}
 
+                    {% assign webp_url = img_url | replace: '.jpg', '.webp' | replace: '.jpeg', '.webp' | replace: '.png', '.webp' | replace: '.JPG', '.webp' | replace: '.JPEG', '.webp' | replace: '.PNG', '.webp' %}
                     {% if site.lazyimages == "enabled" and include.disable_lazy != true %}
-                        <img class="img-fluid lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; height: 100%; object-fit: cover;" decoding="async">
+                        <picture>
+                            <source type="image/webp" data-srcset="{{ webp_url }}">
+                            <img class="img-fluid lazyimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAACCAQAAAA3fa6RAAAADklEQVR42mNkAANGCAUAACMAA2w/AMgAAAAASUVORK5CYII=" data-src="{{ img_url }}" alt="{{ post.title }}" style="width: 100%; height: 100%; object-fit: cover;" decoding="async">
+                        </picture>
                     {% else %}
-                        <img class="img-fluid" src="{{ img_url }}" alt="{{ post.title }}" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;" decoding="async">
+                        <picture>
+                            <source type="image/webp" srcset="{{ webp_url }}">
+                            <img class="img-fluid" src="{{ img_url }}" alt="{{ post.title }}" loading="lazy" style="width: 100%; height: 100%; object-fit: cover;" decoding="async">
+                        </picture>
                     {% endif %}
                     {% if post.tags %}
                         <div class="post-tag">

--- a/_plugins/webp_converter.rb
+++ b/_plugins/webp_converter.rb
@@ -1,0 +1,61 @@
+require 'fileutils'
+require 'thread'
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  puts "Converting images to WebP..."
+  
+  site_images_dir = File.join(site.dest, 'assets', 'images')
+  
+  if Dir.exist?(site_images_dir)
+    images = Dir.glob(File.join(site_images_dir, '**', '*.{jpg,jpeg,png,JPG,JPEG,PNG}'))
+    
+    # Process images in parallel using threads
+    threads = []
+    mutex = Mutex.new
+    thread_count = [4, images.size].min # Use up to 4 threads
+    
+    images.each_slice((images.size.to_f / thread_count).ceil) do |image_batch|
+      threads << Thread.new do
+        image_batch.each do |image_path|
+          webp_path = image_path.sub(/\.(jpg|jpeg|png|JPG|JPEG|PNG)$/i, '.webp')
+          
+          # Skip if webp is newer than source
+          next if File.exist?(webp_path) && File.mtime(webp_path) >= File.mtime(image_path)
+          
+          # Convert to WebP with error handling
+          begin
+            # First try to fix corrupted PNGs by re-saving them
+            if image_path =~ /\.png$/i
+              temp_path = "#{image_path}.tmp"
+              system("magick", image_path, temp_path, err: File::NULL, out: File::NULL)
+              if File.exist?(temp_path) && File.size(temp_path) > 0
+                FileUtils.mv(temp_path, image_path, force: true)
+              end
+            end
+            
+            # Convert to WebP
+            success = system("magick", image_path, "-quality", "85", "-define", "webp:method=6", webp_path, err: File::NULL, out: File::NULL)
+            
+            if success && File.exist?(webp_path)
+              original_size = File.size(image_path) / 1024.0
+              webp_size = File.size(webp_path) / 1024.0
+              savings = ((original_size - webp_size) / original_size * 100).round(1)
+              
+              mutex.synchronize do
+                puts "  ✓ #{File.basename(image_path)} (#{original_size.round(1)}KB → #{webp_size.round(1)}KB, #{savings}% smaller)"
+              end
+            end
+          rescue => e
+            mutex.synchronize do
+              puts "  ✗ Skipped: #{File.basename(image_path)}"
+            end
+          end
+        end
+      end
+    end
+    
+    threads.each(&:join)
+  end
+  
+  puts "WebP conversion complete!"
+end

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -283,3 +283,9 @@ html.dark-mode body,
     color: #000 !important;
     box-shadow: 0 8px 25px rgba(255, 255, 255, 0.1);
 }
+
+/* Gallery Loading Skeleton Dark Mode */
+.dark-mode .skeleton-card {
+    background: linear-gradient(90deg, #2a2a2a 25%, #333 50%, #2a2a2a 75%);
+    background-size: 200% 100%;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -221,6 +221,25 @@ h1, h2, h3, h4, h5, h6, .navbar-brand {
     width: 100%;
 }
 
+/* Gallery Loading Skeleton */
+.gallery-loading-skeleton {
+    padding: 2rem 0;
+}
+
+.skeleton-card {
+    width: 100%;
+    height: 350px;
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+    background-size: 200% 100%;
+    animation: loading 1.5s infinite;
+    border-radius: 8px;
+}
+
+@keyframes loading {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
 
 .magazine-link .arrow {
     display: inline-block;

--- a/gallery.html
+++ b/gallery.html
@@ -3,37 +3,16 @@ layout: default
 title: Gallery
 ---
 
-<!-- Posts Index -->
- <!--
-<section class="recent-posts">
-    <div class="section-title">
-        <h2><span>Gallery</span></h2>
-    </div>
-
-    <div class="row listrecent">
-        {% for post in site.posts %}
-            {% if post.categories contains "pictures" %}
-                <div class="pictures-container">
-                        <div class="picture-inner-rectangle">
-                            <img src="{{ post.image }}" 
-                                 alt="{{ post.title }}" 
-                                 class="pictures-image">
-                            <p class="pictures-name">
-                                <strong>{{ post.title }}</strong>
-                            </p>
-                            <p class="pictures-author">
-                                <strong>{{ post.author }}</strong>
-                            </p>
-                            <p class="pictures-desc">
-                                <strong>{{ post.description }}</strong>
-                            </p>
-                        </div>
-                </div>
-            {% endif %}
+<!-- Loading Skeleton -->
+<div id="gallery-loading" class="gallery-loading-skeleton">
+    <div class="masonry-grid">
+        {% for i in (1..12) %}
+        <div class="masonry-item">
+            <div class="skeleton-card"></div>
+        </div>
         {% endfor %}
     </div>
-</section>
--->
+</div>
 
 <section class="recent-posts">
     <div class="section-title section-hero-header">
@@ -41,7 +20,7 @@ title: Gallery
     </div>
 
     <!-- Flex container for all posts -->
-    <div class="masonry-grid fade-up-element">
+    <div class="masonry-grid" id="gallery-grid" style="opacity: 0; transform: translateY(30px); transition: opacity 0.8s ease, transform 0.8s ease;">
         {% for post in site.posts %}
             {% if post.categories contains "pictures" %}
                 <!-- Individual post -->
@@ -52,6 +31,24 @@ title: Gallery
         {% endfor %}
     </div>
 </section>
+
+<script>
+// Hide skeleton and fade up gallery when images load
+window.addEventListener('load', function() {
+    document.getElementById('gallery-loading').style.display = 'none';
+    var grid = document.getElementById('gallery-grid');
+    grid.style.opacity = '1';
+    grid.style.transform = 'translateY(0)';
+});
+
+// Fallback: hide skeleton and fade up after 3 seconds regardless
+setTimeout(function() {
+    document.getElementById('gallery-loading').style.display = 'none';
+    var grid = document.getElementById('gallery-grid');
+    grid.style.opacity = '1';
+    grid.style.transform = 'translateY(0)';
+}, 3000);
+</script>
 
 
 


### PR DESCRIPTION
This PR
1) Automatically converts pngs to webp using github actions
2) Uses compressed webp using `magick convert`, which is faster, better visuals.
3) fix Gallery page's weird manual scroll fade up, not it will auto fade up when everything loads up

A lot of performance UP using webp!!