### PR TITLE
News Popup and image supported in News and announcements

### DIFF
--- a/_includes/news-modal.html
+++ b/_includes/news-modal.html
@@ -55,22 +55,6 @@
 
 .modal-scrollable {
     overflow-y: auto;
-    scrollbar-width: thin;
-}
-
-.modal-scrollable::-webkit-scrollbar {
-    width: 6px;
-}
-.modal-scrollable::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.05);
-}
-.modal-scrollable::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.6);
-    border-radius: 10px;
-    border: 2px solid #1a1a1a;
-}
-.modal-scrollable::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.9);
 }
 
 .news-modal-close {

--- a/_includes/news-modal.html
+++ b/_includes/news-modal.html
@@ -1,0 +1,148 @@
+<!-- News & Announcements Modal -->
+<div class="modal fade" id="newsModal" tabindex="-1" role="dialog" aria-labelledby="newsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content news-insta-modal">
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title text-muted small text-uppercase font-weight-bold" id="newsModalLabel" style="letter-spacing: 1px;">Details</h5>
+                <button type="button" class="close news-modal-close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body pt-2 pb-4 px-4 modal-scrollable">
+                <div id="modal-news-image-container" class="mb-4 text-center d-none">
+                    <img id="modal-news-image" src="" alt="" class="img-fluid rounded shadow-sm" style="max-height: 400px; width: 100%; object-fit: cover;">
+                </div>
+                <h2 id="modal-news-title" class="mb-3 font-weight-bold" style="font-family: 'Playfair Display', serif; line-height: 1.2;"></h2>
+                <hr class="my-3" style="opacity: 0.1;">
+                <div id="modal-news-description" class="news-full-content mb-4" style="font-size: 1.1rem; line-height: 1.6; color: #eee;"></div>
+                
+                <div class="d-flex align-items-center justify-content-between flex-wrap mt-auto pt-3 border-top" style="gap: 15px;">
+                    <div id="modal-news-date-container">
+                        <span id="modal-news-date" class="deadline-badge"></span>
+                    </div>
+                    <a id="modal-news-link" href="#" target="_blank" rel="noopener noreferrer" class="magazine-link" style="font-size: 1.1rem;">
+                        <span id="modal-news-link-text">Read More</span> <span class="arrow">&xrarr;</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+.news-insta-modal {
+    background-color: #1a1a1a;
+    color: #fff;
+    border-radius: 20px;
+    border: 1px solid #333;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-scrollable {
+    overflow-y: auto;
+    scrollbar-width: thin;
+}
+
+.modal-scrollable::-webkit-scrollbar {
+    width: 6px;
+}
+.modal-scrollable::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.05);
+}
+.modal-scrollable::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 10px;
+}
+
+.news-modal-close {
+    position: absolute;
+    right: 20px;
+    top: 15px;
+    font-size: 2rem;
+    font-weight: 300;
+    z-index: 10;
+    opacity: 0.8;
+    color: #fff;
+    transition: opacity 0.2s;
+    outline: none !important;
+    text-shadow: none;
+}
+
+.news-modal-close:hover {
+    opacity: 1;
+    color: #fff;
+}
+
+.news-full-content {
+    white-space: pre-wrap;
+    color: #eee;
+}
+
+.news-insta-modal hr {
+    border-top-color: rgba(255,255,255,0.1);
+}
+
+.news-insta-modal .modal-header .modal-title {
+    color: #888 !important;
+}
+
+.news-insta-modal .magazine-link {
+    color: #fff !important;
+}
+
+@media (max-width: 576px) {
+    .news-insta-modal {
+        margin: 10px;
+    }
+}
+</style>
+
+<script>
+window.showNewsDetails = function(data) {
+    const modal = $('#newsModal');
+    const title = data.title || '';
+    const description = data.description || '';
+    const dateText = data.dateText || '';
+    const link = data.link || '#';
+    const linkText = data.linkText || 'Read More';
+    const type = data.type || 'News';
+    const imageUrl = data.image || '';
+
+    document.getElementById('newsModalLabel').textContent = type;
+    document.getElementById('modal-news-title').textContent = title;
+    document.getElementById('modal-news-description').textContent = description;
+    
+    const imgContainer = document.getElementById('modal-news-image-container');
+    const imgEl = document.getElementById('modal-news-image');
+    if (imageUrl) {
+        imgEl.src = imageUrl;
+        imgEl.alt = title;
+        imgContainer.classList.remove('d-none');
+    } else {
+        imgContainer.classList.add('d-none');
+    }
+
+    const dateEl = document.getElementById('modal-news-date');
+    if (dateText) {
+        dateEl.innerHTML = `<i class="far fa-calendar-alt mr-1"></i> ${dateText}`;
+        document.getElementById('modal-news-date-container').style.display = 'block';
+    } else {
+        document.getElementById('modal-news-date-container').style.display = 'none';
+    }
+
+    const linkEl = document.getElementById('modal-news-link');
+    if (link && link !== '#') {
+        linkEl.href = link;
+        document.getElementById('modal-news-link-text').textContent = linkText;
+        linkEl.style.display = 'inline-flex';
+    } else {
+        linkEl.style.display = 'none';
+    }
+
+    modal.modal('show');
+};
+</script>

--- a/_includes/news-modal.html
+++ b/_includes/news-modal.html
@@ -9,16 +9,16 @@
                 </button>
             </div>
             <div class="modal-body pt-2 pb-4 px-4 modal-scrollable">
+                <h2 id="modal-news-title" class="mb-3 font-weight-bold" style="font-family: 'Playfair Display', serif; line-height: 1.2; color: #fff;"></h2>
                 <div id="modal-news-image-container" class="mb-4 text-center d-none">
-                    <img id="modal-news-image" src="" alt="" class="img-fluid rounded shadow-sm" style="max-height: 400px; width: 100%; object-fit: cover;">
+                    <img id="modal-news-image" src="" alt="" class="img-fluid rounded shadow-sm" style="max-height: 600px; width: 100%; object-fit: contain; margin: 0 auto; display: block;">
                 </div>
-                <h2 id="modal-news-title" class="mb-3 font-weight-bold" style="font-family: 'Playfair Display', serif; line-height: 1.2;"></h2>
                 <hr class="my-3" style="opacity: 0.1;">
                 <div id="modal-news-description" class="news-full-content mb-4" style="font-size: 1.1rem; line-height: 1.6; color: #eee;"></div>
                 
-                <div class="d-flex align-items-center justify-content-between flex-wrap mt-auto pt-3 border-top" style="gap: 15px;">
+                <div class="d-flex align-items-center justify-content-between flex-wrap mt-auto pt-3 border-top" style="gap: 15px; border-top-color: rgba(255,255,255,0.1) !important;">
                     <div id="modal-news-date-container">
-                        <span id="modal-news-date" class="deadline-badge"></span>
+                        <span id="modal-news-date" class="deadline-badge-modal"></span>
                     </div>
                     <a id="modal-news-link" href="#" target="_blank" rel="noopener noreferrer" class="magazine-link" style="font-size: 1.1rem;">
                         <span id="modal-news-link-text">Read More</span> <span class="arrow">&xrarr;</span>
@@ -30,6 +30,17 @@
 </div>
 
 <style>
+.deadline-badge-modal {
+    background: rgba(255,255,255,0.15);
+    padding: 6px 15px;
+    border-radius: 50px;
+    font-size: 0.9rem;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.3);
+    display: inline-flex;
+    align-items: center;
+    font-weight: 500;
+}
 .news-insta-modal {
     background-color: #1a1a1a;
     color: #fff;
@@ -54,8 +65,12 @@
     background: rgba(255, 255, 255, 0.05);
 }
 .modal-scrollable::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.6);
     border-radius: 10px;
+    border: 2px solid #1a1a1a;
+}
+.modal-scrollable::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.9);
 }
 
 .news-modal-close {
@@ -112,12 +127,15 @@ window.showNewsDetails = function(data) {
     const type = data.type || 'News';
     const imageUrl = data.image || '';
 
+    // Reset image first
+    const imgEl = document.getElementById('modal-news-image');
+    imgEl.src = '';
+    
     document.getElementById('newsModalLabel').textContent = type;
     document.getElementById('modal-news-title').textContent = title;
     document.getElementById('modal-news-description').textContent = description;
     
     const imgContainer = document.getElementById('modal-news-image-container');
-    const imgEl = document.getElementById('modal-news-image');
     if (imageUrl) {
         imgEl.src = imageUrl;
         imgEl.alt = title;

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -213,6 +213,8 @@
       </div>
     </div>
 
+    {% include news-modal.html %}
+
     <!-- Categories Jumbotron
 ================================================== -->
     <div class="jumbotron fortags"></div>

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -307,15 +307,31 @@ html.dark-mode body,
     background-size: 200% 100%;
 }
 
-/* Scrollbar Dark Mode */
-.dark-mode .announcements-scroll-container::-webkit-scrollbar-track {
+/* Scrollbar Dark Mode - Simple & Global */
+.dark-mode {
+    scrollbar-color: rgba(255, 255, 255, 0.5) rgba(0, 0, 0, 0.1);
+    scrollbar-width: thin;
+}
+
+/* Webkit Scrollbars in Dark Mode */
+.dark-mode ::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+}
+
+.dark-mode ::-webkit-scrollbar-track {
     background: rgba(255, 255, 255, 0.05) !important;
 }
-.dark-mode .announcements-scroll-container::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.3) !important;
-    border: 2px solid #121212 !important;
+
+.dark-mode ::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.4) !important;
+    border-radius: 10px !important;
+    border: 2px solid transparent !important;
+    background-clip: padding-box !important;
 }
-.dark-mode .announcements-scroll-container::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.5) !important;
+
+.dark-mode ::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.6) !important;
+    background-clip: padding-box !important;
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -771,6 +771,15 @@ h1, h2, h3, h4, h5, h6, .navbar-brand {
 
 
 /* --- Announcements Styles --- */
+.news-desc-preview {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    line-height: 1.5;
+    margin-top: 5px;
+}
+
 .deadline-badge {
     background: rgba(0,0,0,0.05);
     padding: 4px 12px;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -478,25 +478,7 @@ h1, h2, h3, h4, h5, h6, .navbar-brand {
     margin-top: 15px;
     padding-right: 10px;
     overflow-y: auto;
-    scrollbar-width: thin;
     flex-grow: 1;
-}
-
-.side-scroll-list-container::-webkit-scrollbar {
-    width: 6px;
-}
-.side-scroll-list-container::-webkit-scrollbar-track {
-    background: rgba(128, 128, 128, 0.05);
-    border-radius: 10px;
-}
-.side-scroll-list-container::-webkit-scrollbar-thumb {
-    background: rgba(128, 128, 128, 0.2);
-    border-radius: 10px;
-}
-
-.side-scroll-list-widget .section-title h2 {
-    font-size: 1.8rem !important;
-    margin-bottom: 0;
 }
 
 /* --- Reusable Carousel Widget Style --- */
@@ -745,30 +727,6 @@ h1, h2, h3, h4, h5, h6, .navbar-brand {
 }
 .mini-card h5 { font-weight: 700; margin-bottom: 5px; }
 .mini-card p { font-size: 0.85rem; margin-bottom: 0; opacity: 0.7; }
-
-/* Custom Scrollbar for Past Minis & Announcements */
-#past-minis-list::-webkit-scrollbar,
-.announcements-scroll-container::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-}
-#past-minis-list::-webkit-scrollbar-track,
-.announcements-scroll-container::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.05);
-    border-radius: 10px;
-}
-#past-minis-list::-webkit-scrollbar-thumb,
-.announcements-scroll-container::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2); /* Default for light mode */
-    border: 2px solid transparent;
-    background-clip: content-box;
-    border-radius: 10px;
-}
-#past-minis-list::-webkit-scrollbar-thumb:hover,
-.announcements-scroll-container::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.4);
-}
-
 
 /* --- Announcements Styles --- */
 .news-desc-preview {

--- a/assets/js/announcements-loader.js
+++ b/assets/js/announcements-loader.js
@@ -36,6 +36,7 @@
           description: f['Description'] || f['description'] || '',
           link: f['Link'] || f['link'] || '#',
           link_text: f['Link Text'] || f['link text'] || 'Apply Here',
+          image: f['Image'] && f['Image'][0] ? f['Image'][0].url : (f['image'] && f['image'][0] ? f['image'][0].url : ''),
           deadline: f['Deadline'] || f['deadline'] || '',
           deadline_text: (typeof formatHumanDate === 'function' ? formatHumanDate(f['Deadline'] || f['deadline']) : (f['Deadline'] || f['deadline'] || ''))
         };
@@ -71,6 +72,7 @@
           description: a.description,
           link: a.link,
           linkText: a.link_text,
+          image: a.image,
           dateText: a.deadline_text || a.deadline,
           type: 'Announcements'
         }).replace(/"/g, '&quot;');
@@ -135,11 +137,6 @@
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', loadAnnouncements);
-  } else {
-    loadAnnouncements();
-  }
-})();
-Listener('DOMContentLoaded', loadAnnouncements);
   } else {
     loadAnnouncements();
   }

--- a/assets/js/announcements-loader.js
+++ b/assets/js/announcements-loader.js
@@ -65,35 +65,64 @@
         return bDate - aDate;
       });
       
-      const html = active.map(a => `
+      const html = active.map(a => {
+        const itemData = JSON.stringify({
+          title: a.title,
+          description: a.description,
+          link: a.link,
+          linkText: a.link_text,
+          dateText: a.deadline_text || a.deadline,
+          type: 'Announcements'
+        }).replace(/"/g, '&quot;');
+
+        return `
         <li class="mb-4 pb-3 border-bottom">
-          <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
-            ${a.title}
-            <span class="text-muted" style="font-weight: 400; font-size: 0.95rem; margin-left: 8px;">— ${a.description}</span>
+          <div class="news-item-content">
+            <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
+              ${a.title}
+            </div>
+            <div class="news-desc-preview text-muted" style="font-weight: 400; font-size: 0.95rem;">
+              ${a.description}
+            </div>
           </div>
           <div class="mt-3 ${a.deadline ? 'd-flex align-items-center justify-content-between flex-wrap' : ''}" style="gap: 10px;">
-            <a href="${a.link}" target="_blank" rel="noopener noreferrer" class="magazine-link" style="font-size: 0.95rem; padding-bottom: 2px;">${a.link_text} <span class="arrow" style="font-size: 1.2rem; margin-left: 8px;">&xrarr;</span></a>
+            <a href="javascript:void(0)" onclick="showNewsDetails(${itemData})" class="magazine-link" style="font-size: 0.95rem; padding-bottom: 2px;">Read More <span class="arrow" style="font-size: 1.2rem; margin-left: 8px;">&xrarr;</span></a>
             ${a.deadline ? `<span class="deadline-badge"><i class="far fa-calendar-alt mr-1"></i> Deadline: ${a.deadline_text || a.deadline}</span>` : ''}
           </div>
         </li>
-      `).join('');
+      `;}).join('');
       
       const pastHtml = past.length > 0 ? `
         <div class="mt-5 mb-3">
           <h5 class="text-muted text-uppercase" style="letter-spacing: 2px; font-size: 0.9rem; font-weight: 700; border-bottom: 1px solid rgba(128,128,128,0.2); padding-bottom: 10px;">Past Announcements</h5>
         </div>
-        ${past.map(a => `
+        ${past.map(a => {
+          const itemData = JSON.stringify({
+            title: a.title,
+            description: a.description,
+            link: a.link,
+            linkText: a.link_text,
+            image: a.image,
+            dateText: a.deadline_text || a.deadline,
+            type: 'Past Announcements'
+          }).replace(/"/g, '&quot;');
+          
+          return `
           <li class="mb-3 pb-2 border-bottom">
-            <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
-              ${a.title}
-              <span class="text-muted" style="font-weight: 400; font-size: 0.95rem; margin-left: 8px;">— ${a.description}</span>
+            <div class="news-item-content">
+              <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
+                ${a.title}
+              </div>
+              <div class="news-desc-preview text-muted" style="font-weight: 400; font-size: 0.95rem;">
+                ${a.description}
+              </div>
             </div>
             <div class="mt-2 d-flex align-items-center justify-content-between flex-wrap" style="gap: 10px;">
-              <a href="${a.link}" target="_blank" rel="noopener noreferrer" class="magazine-link" style="font-size: 0.85rem; padding-bottom: 2px;">Details <span class="arrow" style="font-size: 1rem; margin-left: 5px;">&xrarr;</span></a>
+              <a href="javascript:void(0)" onclick="showNewsDetails(${itemData})" class="magazine-link" style="font-size: 0.85rem; padding-bottom: 2px;">Read More <span class="arrow" style="font-size: 1rem; margin-left: 5px;">&xrarr;</span></a>
               <span class="deadline-badge"><i class="far fa-calendar-alt mr-1"></i> Deadline: ${a.deadline_text || a.deadline}</span>
             </div>
           </li>
-        `).join('')}
+        `;}).join('')}
       ` : '';
       
       listEl.innerHTML = html + pastHtml || '<li class="text-muted text-center py-3">No announcements</li>';
@@ -106,6 +135,11 @@
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', loadAnnouncements);
+  } else {
+    loadAnnouncements();
+  }
+})();
+Listener('DOMContentLoaded', loadAnnouncements);
   } else {
     loadAnnouncements();
   }

--- a/assets/js/news-loader.js
+++ b/assets/js/news-loader.js
@@ -37,6 +37,7 @@
           description: f['Description'] || f['description'] || '',
           link: f['Link'] || f['link'] || '#',
           link_text: f['Link Text'] || f['link text'] || 'Read More',
+          image: f['Image'] && f['Image'][0] ? f['Image'][0].url : (f['image'] && f['image'][0] ? f['image'][0].url : ''),
           published_date: f['Published Date'] || '',
           published_date_text: typeof formatHumanDate === 'function' ? formatHumanDate(f['Published Date']) : (f['Published Date'] || '')
         };
@@ -45,18 +46,33 @@
         return new Date(b.published_date) - new Date(a.published_date);
       });
 
-      const html = newsItems.length > 0 ? newsItems.map(item => `
+      const html = newsItems.length > 0 ? newsItems.map(item => {
+        const itemData = JSON.stringify({
+          title: item.title,
+          description: item.description,
+          link: item.link,
+          linkText: item.link_text,
+          image: item.image,
+          dateText: item.published_date_text,
+          type: 'News & Updates'
+        }).replace(/"/g, '&quot;');
+
+        return `
         <li class="mb-4 pb-3 border-bottom">
-          <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
-            ${item.title}
-            <span class="text-muted" style="font-weight: 400; font-size: 0.95rem; margin-left: 8px;">— ${item.description}</span>
+          <div class="news-item-content">
+            <div class="font-weight-bold" style="font-size: 1.15rem; line-height: 1.4;">
+              ${item.title}
+            </div>
+            <div class="news-desc-preview text-muted" style="font-weight: 400; font-size: 0.95rem;">
+              ${item.description}
+            </div>
           </div>
           <div class="mt-3 d-flex align-items-center justify-content-between flex-wrap" style="gap: 10px;">
-            <a href="${item.link}" target="_blank" rel="noopener noreferrer" class="magazine-link" style="font-size: 0.95rem; padding-bottom: 2px;">${item.link_text} <span class="arrow" style="font-size: 1.2rem; margin-left: 8px;">&xrarr;</span></a>
+            <a href="javascript:void(0)" onclick="showNewsDetails(${itemData})" class="magazine-link" style="font-size: 0.95rem; padding-bottom: 2px;">Read More <span class="arrow" style="font-size: 1.2rem; margin-left: 8px;">&xrarr;</span></a>
             ${item.published_date_text ? `<span class="deadline-badge"><i class="far fa-calendar-alt mr-1"></i> Posted: ${item.published_date_text}</span>` : ''}
           </div>
         </li>
-      `).join('') : '<li class="text-muted text-center py-3">No updates yet</li>';
+      `;}).join('') : '<li class="text-muted text-center py-3">No updates yet</li>';
       
       listEl.innerHTML = html;
       

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ title: Home
             <div class="section-title section-hero-header">
                 <h2 style="font-size: 2.5rem;">NEWS & UPDATES</h2>
             </div>
-            <div class="announcements-scroll-container mt-4 px-2" style="max-height: 400px; overflow-y: auto; scrollbar-width: thin;">
+            <div class="announcements-scroll-container mt-4 px-2" style="max-height: 400px; overflow-y: auto;">
                 <ul class="list-unstyled" id="news-list">
                     <li class="text-muted text-center py-3">Loading news...</li>
                 </ul>
@@ -56,7 +56,7 @@ title: Home
             <div class="section-title section-hero-header">
                 <h2 style="font-size: 2.5rem;">ANNOUNCEMENTS</h2>
             </div>
-            <div class="announcements-scroll-container mt-4 px-2" style="max-height: 400px; overflow-y: auto; scrollbar-width: thin;">
+            <div class="announcements-scroll-container mt-4 px-2" style="max-height: 400px; overflow-y: auto;">
                 <ul class="list-unstyled" id="announcements-list">
                     <li class="text-muted text-center py-3">Loading announcements...</li>
                 </ul>


### PR DESCRIPTION
This PR

1) Implements a news-model card which is pretty popup which opens on "Read More" on News and Announcements. A common thing connected to airtable. 
2) Airtable now supports images for both and this news-model card
3) css styling.